### PR TITLE
Add API integration to fetch and display LPN data

### DIFF
--- a/src/api/LpnApiService.ts
+++ b/src/api/LpnApiService.ts
@@ -1,9 +1,22 @@
-import {UserProp} from "../interfaces/User";
 import axiosInstance from "../utils/axiosInstance";
-import {LPNRequestProp} from "../interfaces/LPN";
+import {LPNProp, LPNRequestProp} from "../interfaces/LPN";
 
-export const createNewLpn = async (lpnRequestProp: LPNRequestProp): Promise<UserProp> => {
+export const createNewLpn = async (lpnRequestProp: LPNRequestProp): Promise<LPNRequestProp> => {
     const response = await axiosInstance.post(`/v1/lpn/new`, lpnRequestProp, {
+        headers: {
+            "Content-Type": "application/json",
+        },
+    });
+
+    if (response.status !== 200) {
+        throw new Error(`${response.status}`);
+    }
+
+    return response.data;
+}
+
+export const getAllLpn = async (): Promise<LPNProp[]> => {
+    const response = await axiosInstance.get(`/v1/lpn`, {
         headers: {
             "Content-Type": "application/json",
         },

--- a/src/pages/Inventory/LPN/LPN.tsx
+++ b/src/pages/Inventory/LPN/LPN.tsx
@@ -1,6 +1,6 @@
 import PageMeta from "../../../components/common/PageMeta";
 import PageBreadcrumb from "../../../components/common/PageBreadCrumb";
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import 'flatpickr/dist/flatpickr.min.css';
 import Loader from "../../UiElements/Loader/Loader";
 import Button from "../../../components/ui/button/Button";
@@ -8,18 +8,15 @@ import {AgGridReact} from "ag-grid-react";
 import { ColDef, ColGroupDef } from 'ag-grid-community';
 import "ag-grid-community/styles/ag-theme-balham.css";
 import {useNavigate} from "react-router";
+import {LPNProp} from "../../../interfaces/LPN";
+import {getAllLpn} from "../../../api/LpnApiService";
 
 
 export default function LPN() {
     const gridRef = useRef<AgGridReact>(null);
     const [loading, setLoading] = useState<boolean>(false);
     const navigate = useNavigate();
-
-
-    const rowData = [
-        { orderId: 101, customer: "Alice", date: "2025-06-06", status: "Pending", total: 120 },
-        { orderId: 102, customer: "Bob", date: "2025-06-05", status: "Shipped", total: 80 },
-    ];
+    const [lpns, setLpns] = useState<LPNProp[]>([]);
 
 
     const columnDefs: (ColDef | ColGroupDef)[] = [
@@ -87,14 +84,6 @@ export default function LPN() {
             editable: false,
             filter: "agTextColumnFilter",
         },
-        {
-            headerName: "Created By",
-            field: "createdBy",
-            sortable: true,
-            width: 200,
-            editable: false,
-            filter: "agTextColumnFilter",
-        },
     ]
 
     const defaultColDef = {
@@ -107,6 +96,22 @@ export default function LPN() {
             };
         }
     };
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const data = await getAllLpn(); // Call API to fetch LPN data
+                setLpns(data); // Set table row data
+            } catch (error) {
+                console.error("Error fetching LPN data: ", error);
+            } finally {
+                setLoading(false); // Hide loader
+            }
+        };
+
+        fetchData();
+    }, []); // Empty dependency array ensures this runs once on mount
+
 
     return (
         <>
@@ -140,7 +145,7 @@ export default function LPN() {
                     {!loading ? (
                         <AgGridReact
                         ref={gridRef}
-                        rowData={rowData}
+                        rowData={lpns}
                         columnDefs={columnDefs}
                         defaultColDef={defaultColDef}
                         headerHeight={40}


### PR DESCRIPTION
Replaced static row data with dynamic data fetched via API. Introduced `useEffect` to call `getAllLpn` and populate the grid with LPN data, improving data accuracy and maintainability. Also refined types and removed unused columns for cleaner implementation.