### PR TITLE
Update workflow to trigger only on pull requests and upgrade action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build and Deploy to VPS
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -117,7 +114,7 @@ jobs:
           cat .env
 
       - name: Upload .env artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: production-env
           path: .env


### PR DESCRIPTION
The workflow no longer triggers on direct pushes to the main branch, reducing unnecessary runs. Additionally, the upload-artifact action was upgraded to version 4 for improved performance and compatibility.