### PR TITLE
Update GitHub Actions to use v4 of artifact actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/package.json') }}
 
       - name: Download .env artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-env
 
@@ -147,7 +147,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-files
           path: build/
@@ -161,13 +161,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-files
           path: build/
 
       - name: Download .env artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-env
 


### PR DESCRIPTION
Upgraded `actions/download-artifact` and `actions/upload-artifact` from v3 to v4 in the workflow file. This ensures compatibility with the latest features and improvements in these actions.