### PR TITLE
Update artifact paths in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: production-env
-          path: .
+          path: .env
 
   build:
     runs-on: ubuntu-latest
@@ -171,6 +171,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: production-env
+          path: .
 
       - name: Deploy to VPS
         env:


### PR DESCRIPTION
Modified the upload and download artifact paths to explicitly handle the `.env` file. This change ensures the correct environment file is transferred during the CI/CD process. No other workflow steps were affected.