### PR TITLE
Remove Babel configuration file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-private-property-in-object"]
-}


### PR DESCRIPTION
The `.babelrc` file is deleted as it is no longer needed. This change suggests the project no longer relies on Babel for compilation, likely due to a migration to a different build tool or preset.