### PR TITLE
Remove Babel configuration file

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="99a9e2c6-4c5c-4429-bc31-62536a99db62" name="Changes" comment="Switch to Jest for testing and update dependencies&#10;&#10;Replaced React Scripts testing with Jest and added Jest configuration. Updated package dependencies to align with the changes and ensure compatibility. Introduced necessary Babel and Jest-related devDependencies for proper testing environment setup.">
-      <change beforePath="$PROJECT_DIR$/babel.config.js" beforeDir="false" afterPath="$PROJECT_DIR$/babel.config.js" afterDir="false" />
+    <list default="true" id="99a9e2c6-4c5c-4429-bc31-62536a99db62" name="Changes" comment="Remove Babel configuration file&#10;&#10;The `.babelrc` file is deleted as it is no longer needed. This change suggests the project no longer relies on Babel for compilation, likely due to a migration to a different build tool or preset.">
       <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
     </list>
@@ -136,7 +135,7 @@
       <workItem from="1749745407633" duration="12921000" />
       <workItem from="1749826851764" duration="14971000" />
       <workItem from="1750088557059" duration="180459000" />
-      <workItem from="1752179952808" duration="2691000" />
+      <workItem from="1752179952808" duration="3122000" />
     </task>
     <task id="LOCAL-00001" summary="Refactor and enhance orders functionality.&#10;&#10;Updated API URL handling with environment variables and added new orders and customer type configurations. Introduced the 'Orders' and 'New Order' pages, improved UI elements, adjusted chart coloring, and optimized table components. Removed unused pages, updated branding, and enhanced error and breadcrumb UX for better consistency.">
       <option name="closed" value="true" />
@@ -466,7 +465,23 @@
       <option name="project" value="LOCAL" />
       <updated>1752182386358</updated>
     </task>
-    <option name="localTasksCounter" value="42" />
+    <task id="LOCAL-00042" summary="Refactor Babel configuration and cleanup package.json.&#10;&#10;Moved `@babel/plugin-proposal-private-property-in-object` from dependencies to Babel plugins in `babel.config.js` to streamline configuration. Removed unnecessary dependency from package.json and updated associated files for consistency.">
+      <option name="closed" value="true" />
+      <created>1752182730574</created>
+      <option name="number" value="00042" />
+      <option name="presentableId" value="LOCAL-00042" />
+      <option name="project" value="LOCAL" />
+      <updated>1752182730574</updated>
+    </task>
+    <task id="LOCAL-00043" summary="Remove Babel configuration file&#10;&#10;The `.babelrc` file is deleted as it is no longer needed. This change suggests the project no longer relies on Babel for compilation, likely due to a migration to a different build tool or preset.">
+      <option name="closed" value="true" />
+      <created>1752182891954</created>
+      <option name="number" value="00043" />
+      <option name="presentableId" value="LOCAL-00043" />
+      <option name="project" value="LOCAL" />
+      <updated>1752182891954</updated>
+    </task>
+    <option name="localTasksCounter" value="44" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -484,8 +499,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Make product sheet table editable and enhance state management&#10;&#10;Added support for inline editing of product sheet fields and updated the table column definitions to handle grouped components. Introduced value mapping functions, persistent login via localStorage, and API integration to update product details dynamically. Updated configurations and utility functions to support these changes." />
-    <MESSAGE value="Remove SignUp page and integrate user and permission management&#10;&#10;The SignUp page was removed from the application as it is no longer necessary. New pages were added for managing users and permissions, enhancing administrative functionality. Adjustments were made to the sidebar, authentication context, and routing to support these updates and the dynamic display of menu items based on the user's role." />
     <MESSAGE value="Refactor User API handling and implement user updates&#10;&#10;Moved User API logic to a dedicated service file for better modularity. Added functionality to update user details via API and handle potential errors. Adjusted components to integrate with the new structure and ensure only applicable users can be edited." />
     <MESSAGE value="Add image management and modal functionality to ProductSheet&#10;&#10;Introduced an &quot;Edit Images&quot; modal for managing product images, along with handlers for saving changes. Updated table styling, added image-related interfaces, and enhanced product data mapping to include images and components. Included Roboto font and related adjustments in `tailwind.config.js`." />
     <MESSAGE value="Refactor modals and update image handling logic&#10;&#10;Moved `ProductImageModal` to a dedicated folder and introduced a new `ComponentModal`. Enhanced image handling with reordering functionality and streamlined component structure. Added updates to dependencies and environment configuration." />
@@ -509,6 +522,8 @@
     <MESSAGE value="Set module type and update TypeScript target to ESNext&#10;&#10;Added &quot;type&quot;: &quot;module&quot; to package.json for native ESM support. Updated tsconfig.json to use ESNext for both target and module, improving compatibility with modern JavaScript features. Excluded node_modules in tsconfig.json to avoid unnecessary processing." />
     <MESSAGE value="Update dependencies, add Babel config, and adjust CI workflow&#10;&#10;Added `@babel/plugin-proposal-private-property-in-object` and updated `axios` to version 1.8.2. Introduced a `.babelrc` file for Babel configuration. Adjusted CI workflow to include `run-tests` as a dependency for the `generate-env` job." />
     <MESSAGE value="Switch to Jest for testing and update dependencies&#10;&#10;Replaced React Scripts testing with Jest and added Jest configuration. Updated package dependencies to align with the changes and ensure compatibility. Introduced necessary Babel and Jest-related devDependencies for proper testing environment setup." />
-    <option name="LAST_COMMIT_MESSAGE" value="Switch to Jest for testing and update dependencies&#10;&#10;Replaced React Scripts testing with Jest and added Jest configuration. Updated package dependencies to align with the changes and ensure compatibility. Introduced necessary Babel and Jest-related devDependencies for proper testing environment setup." />
+    <MESSAGE value="Refactor Babel configuration and cleanup package.json.&#10;&#10;Moved `@babel/plugin-proposal-private-property-in-object` from dependencies to Babel plugins in `babel.config.js` to streamline configuration. Removed unnecessary dependency from package.json and updated associated files for consistency." />
+    <MESSAGE value="Remove Babel configuration file&#10;&#10;The `.babelrc` file is deleted as it is no longer needed. This change suggests the project no longer relies on Babel for compilation, likely due to a migration to a different build tool or preset." />
+    <option name="LAST_COMMIT_MESSAGE" value="Remove Babel configuration file&#10;&#10;The `.babelrc` file is deleted as it is no longer needed. This change suggests the project no longer relies on Babel for compilation, likely due to a migration to a different build tool or preset." />
   </component>
 </project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
       "devDependencies": {
         "@babel/core": "^7.28.0",
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/preset-env": "^7.28.0",
         "@types/jest": "^27.5.2",
         "@types/react-beautiful-dnd": "^13.1.8",
@@ -3796,26 +3797,6 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
-      }
-    },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@testing-library/jest-dom": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@babel/plugin-transform-private-property-in-object": "^7.27.1",
     "@babel/preset-env": "^7.28.0",
     "@types/jest": "^27.5.2",
     "@types/react-beautiful-dnd": "^13.1.8",


### PR DESCRIPTION
The `.babelrc` file is deleted as it is no longer needed. This change suggests the project no longer relies on Babel for compilation, likely due to a migration to a different build tool or preset.