### PR TITLE
Add "Count by Location" option to AppSidebar menu

### DIFF
--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -54,6 +54,7 @@ const navItems: NavItem[] = [
     name: "Count & Search",
     subItems: [
       { name: "Count by SKU", path: "/counting/sku", pro: false, active: true },
+      { name: "Count by Location", path: "/counting/location", pro: false, active: true },
     ],
   },
 ];


### PR DESCRIPTION
This update introduces a new sub-item "Count by Location" under the "Count & Search" menu in the sidebar. It follows the same path as "Count by SKU" and is non-pro and active by default.