### PR TITLE
Add pricing fields and columns for product sheet

### DIFF
--- a/src/interfaces/Product.ts
+++ b/src/interfaces/Product.ts
@@ -30,6 +30,9 @@ export type ProductDetailProp = {
     ewfmain: boolean | false;
     components: {id: number;componentId: number; sku: string; quantity: number; pos: number }[],
     images: ImageProp | { cgi: [], img: [], dim: []};
+    ewfdirectPrice: number;
+    ewfdirectManualPrice: number;
+    promotion: number;
 };
 export type ProductProp = {
     id: number;
@@ -71,6 +74,8 @@ export type ProductDetailRequestProp = {
     houstondirect: boolean;
     ewfmain: boolean;
     images: ImageProp;
+    ewfdirectManualPrice: number;
+    promotion: number;
 }
 
 export type ProductInventoryProp = {

--- a/src/pages/Product/ProductSheet.tsx
+++ b/src/pages/Product/ProductSheet.tsx
@@ -228,6 +228,48 @@ export default function ProductSheet() {
                 fontSize: '13px' },
         },
         {
+            headerName: "Prices",
+            children: [
+                {
+                    headerName: "Sale",
+                    columnGroupShow: "open",
+                    field: "ewfdirectPrice",
+                    width: 100,
+                    cellStyle: {
+                        fontWeight: '500',
+                        textAlign: 'start',
+                        fontSize: '13px' ,
+                        border: "1px solid #ccc"},
+                },
+                {
+                    headerName: "Manual",
+                    columnGroupShow: "open",
+                    field: "ewfdirectManualPrice",
+                    editable: true,
+                    width: 100,
+                    cellStyle: {
+                        fontWeight: '500',
+                        textAlign: 'start',
+                        fontSize: '13px' ,
+                        border: "1px solid #ccc"},
+
+                },
+                {
+                    headerName: "Promotion",
+                    columnGroupShow: "open",
+                    field: "promotion",
+                    editable: true,
+                    width: 100,
+                    cellStyle: {
+                        fontWeight: '500',
+                        textAlign: 'start',
+                        fontSize: '13px' ,
+                        border: "1px solid #ccc"},
+                },
+            ],
+            tooltipField: "Price",
+        },
+        {
             headerName: "UPC",
             field: "upc",
             sortable: true,

--- a/src/utils/mapFunctions.ts
+++ b/src/utils/mapFunctions.ts
@@ -65,6 +65,8 @@ export const mapProductDetailPropToRequest = (
         ewfmain,
         images,
         components, // Include components from the input object
+        ewfdirectManualPrice,
+        promotion,
     } = product;
 
     return {
@@ -93,5 +95,7 @@ export const mapProductDetailPropToRequest = (
         houstondirect,
         ewfmain,
         components: mapComponentsToMinimalFormat(components), // Apply mapping to components
+        ewfdirectManualPrice,
+        promotion,
     };
 };


### PR DESCRIPTION
Introduced new fields `ewfdirectPrice`, `ewfdirectManualPrice`, and `promotion` to support additional pricing details. Updated the ProductSheet table to include corresponding columns and enhanced mapping functions to handle these new fields.