### PR TITLE
Remove setLoading from dependency array in BreakDownLPN

### DIFF
--- a/src/pages/Inventory/LPN/BreakDownLPN.tsx
+++ b/src/pages/Inventory/LPN/BreakDownLPN.tsx
@@ -36,7 +36,7 @@ const BreakDownLPN: React.FC<PutAwayModalProps> = ({onCancel, lpnProp, setLoadin
         };
 
         fetchLooseInventory();
-    }, [handleError, lpnProp.tagID, setLoading]);
+    }, [handleError, lpnProp.tagID]);
 
     const handleSubmit = async () => {
         setLoading(true);


### PR DESCRIPTION
The `setLoading` function does not need to be in the dependency array as it is guaranteed to remain stable. This change prevents unnecessary re-renders and ensures better performance.