### PR TITLE
Fix missing dependency in useEffect dependencies array

### DIFF
--- a/src/pages/Inventory/LPN/BreakDownLPN.tsx
+++ b/src/pages/Inventory/LPN/BreakDownLPN.tsx
@@ -36,7 +36,7 @@ const BreakDownLPN: React.FC<PutAwayModalProps> = ({onCancel, lpnProp, setLoadin
 
 
 
-    }, [handleError, lpnProp.tagID]);
+    }, [handleError, lpnProp.tagID, setLoading]);
 
     const handleSubmit = async () => {
         setLoading(true);


### PR DESCRIPTION
Added `setLoading` to the dependencies array of useEffect to prevent potential stale closures and ensure proper functionality. This change aligns with React best practices for managing side effects.