### PR TITLE
Refactor fetchLooseInventory function in useEffect hook

### DIFF
--- a/src/pages/Inventory/LPN/BreakDownLPN.tsx
+++ b/src/pages/Inventory/LPN/BreakDownLPN.tsx
@@ -19,24 +19,22 @@ const BreakDownLPN: React.FC<PutAwayModalProps> = ({onCancel, lpnProp, setLoadin
 
     const {sendNotification} = useNotification();
     const handleError = useErrorHandler();
-
+    const fetchLooseInventory = async () => {
+        setLoading(true);
+        try {
+            const getLoose = await getLooseInventory(lpnProp.tagID);
+            setLooseQty(getLoose);
+            setLoading(false)
+        } catch (error) {
+            handleError(error);
+        }
+    };
     useEffect(() => {
-        const fetchLooseInventory = async () => {
-            setLoading(true);
-            try {
-                const getLoose = await getLooseInventory(lpnProp.tagID);
-                setLooseQty(getLoose);
-                setLoading(false)
-            } catch (error) {
-                handleError(error);
-            }
-        };
+
 
         fetchLooseInventory();
 
-
-
-    }, [handleError, lpnProp.tagID, setLoading]);
+    }, [lpnProp.tagID, setLoading]);
 
     const handleSubmit = async () => {
         setLoading(true);


### PR DESCRIPTION
Moved the fetchLooseInventory function definition outside of the useEffect hook to improve code readability and reusability. This change simplifies the structure within useEffect and ensures better separation of concerns.