### PR TITLE
Refactor fetchLooseInventory to be within useEffect

### DIFF
--- a/src/pages/Inventory/LPN/BreakDownLPN.tsx
+++ b/src/pages/Inventory/LPN/BreakDownLPN.tsx
@@ -19,19 +19,18 @@ const BreakDownLPN: React.FC<PutAwayModalProps> = ({onCancel, lpnProp, setLoadin
 
     const {sendNotification} = useNotification();
     const handleError = useErrorHandler();
-    const fetchLooseInventory = async () => {
-        setLoading(true);
-        try {
-            const getLoose = await getLooseInventory(lpnProp.tagID);
-            setLooseQty(getLoose);
-            setLoading(false)
-        } catch (error) {
-            handleError(error);
-        }
-    };
+
     useEffect(() => {
-
-
+        const fetchLooseInventory = async () => {
+            setLoading(true);
+            try {
+                const getLoose = await getLooseInventory(lpnProp.tagID);
+                setLooseQty(getLoose);
+                setLoading(false)
+            } catch (error) {
+                handleError(error);
+            }
+        };
         fetchLooseInventory();
 
     }, [lpnProp.tagID, setLoading]);


### PR DESCRIPTION
Moved the fetchLooseInventory function inside the useEffect hook to simplify its scope and ensure it is directly tied to the lifecycle behavior